### PR TITLE
Request op (+o) from ChanServ on joining a channel

### DIFF
--- a/bot.p6
+++ b/bot.p6
@@ -31,6 +31,12 @@ plugins =>
         }
         Nil
     }
+    
+    multi method irc-join ($e where .nick eq $nick) {
+        $e.irc.send-cmd: 'CS', 'op', $e.channel;
+        Nil
+    }
+    
     multi method irc-privmsg-channel ($e) {
         %wait-list{$e.nick} and $l.protect: { %wait-list{$e.nick} = now if %wait-list{$e.nick} }
         $.NEXT


### PR DESCRIPTION
Preferring to use `CS op $e.channel` over `PRIVMSG ChanServ op $e.channel`, as the former uses server command parsing to avoid channel services impersonation attacks